### PR TITLE
Make Firepad.TextOperation public

### DIFF
--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -303,3 +303,4 @@ firepad.Firepad = (function(global) {
 // Export Text class.
 firepad.Firepad.Formatting = firepad.Formatting;
 firepad.Firepad.Text = firepad.Text;
+firepad.Firepad.TextOperation = firepad.TextOperation;


### PR DESCRIPTION
Anyone looking to play around with revision history in FirePad is going to need access to TextOperation to apply selective commits, replay history etc.
