### PR TITLE
Added RichTextCodemirror methods for working with entity attributes

### DIFF
--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -23,6 +23,7 @@ firepad.RichTextCodeMirror = (function () {
     this.options_ = options || { };
     this.entityManager_ = entityManager;
     this.currentAttributes_ = null;
+    this.currentEntityAttributes_ = null;
 
     var self = this;
     this.annotationList_ = new AnnotationList(
@@ -97,6 +98,7 @@ firepad.RichTextCodeMirror = (function () {
         });
 
       this.updateCurrentAttributes_();
+      this.cacheCurrentEntityAttributes_();
     }
   };
 
@@ -128,6 +130,75 @@ firepad.RichTextCodeMirror = (function () {
       this.trigger('attributesChange', this, newChangeList.next);
     }
   };
+
+  RichTextCodeMirror.prototype.setEntityAttribute = function(attribute, value) {
+    var cm = this.codeMirror;
+    if (this.emptySelection_()) {
+      var attrs = this.getCurrentEntityAttributes_();
+
+      var anchor = cm.indexFromPos(cm.getCursor('anchor'));
+      var head = cm.indexFromPos(cm.getCursor('head'));
+      var pos = (anchor > head) ? head + 1 : head;
+
+      this.updateEntityAttributes(pos,
+        function(attributes) {
+          if (value == false || value == null) {
+            delete attributes[attribute];
+          } else {
+            attributes[attribute] = value;
+          }
+        }
+      );
+      this.updateCurrentAttributes_();
+      this.cacheCurrentEntityAttributes_();
+    }
+  }
+
+  RichTextCodeMirror.prototype.updateEntityAttributes = function(pos, updateFn, origin) {
+    var newChangeList = { }, newChange = newChangeList;
+    var self = this;
+
+    var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
+    // We are at the beginning of the line
+    if (spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {
+      pos -= 1;
+    } else if (spans.length > 1) {
+      firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
+      pos = pos;
+    }
+
+    this.annotationList_.updateSpan(new Span(pos, 1), function(annotation, length) {
+      var attributes = { };
+      for(var attr in annotation.attributes) {
+        attributes[attr] = annotation.attributes[attr];
+      }
+
+      updateFn(attributes);
+
+      // changedAttributes will be the attributes we changed, with their new values.
+      // changedAttributesInverse will be the attributes we changed, with their old values.
+      var changedAttributes = { }, changedAttributesInverse = { };
+      self.computeChangedAttributes_(annotation.attributes, attributes, changedAttributes, changedAttributesInverse);
+      if (!emptyAttributes(changedAttributes)) {
+        newChange.next = {
+          start: pos,
+          end: pos + length,
+          attributes: changedAttributes,
+          attributesInverse: changedAttributesInverse,
+          origin: origin
+        };
+        newChange = newChange.next;
+      }
+
+      pos += length;
+      return new RichTextAnnotation(attributes);
+    });
+
+    if (newChangeList.next) {
+      this.trigger('attributesChange', this, newChangeList.next);
+    }
+  };
+
 
   RichTextCodeMirror.prototype.computeChangedAttributes_ = function(oldAttrs, newAttrs, changed, inverseChanged) {
     var attrs = { }, attr;
@@ -673,6 +744,7 @@ firepad.RichTextCodeMirror = (function () {
 
   RichTextCodeMirror.prototype.onCursorActivity_ = function() {
     this.updateCurrentAttributes_();
+    this.cacheCurrentEntityAttributes_();
   };
 
   RichTextCodeMirror.prototype.getCurrentAttributes_ = function() {
@@ -719,6 +791,42 @@ firepad.RichTextCodeMirror = (function () {
       line--;
     }
     return this.getLineAttributes_(line);
+  };
+
+  RichTextCodeMirror.prototype.getCurrentEntityAttributes_ = function() {
+    if (!this.currentEntityAttributes_) {
+      this.cacheCurrentEntityAttributes_();
+    }
+    return this.currentEntityAttributes_;
+  };
+
+  RichTextCodeMirror.prototype.cacheCurrentEntityAttributes_ = function() {
+    var pos;
+    var cm = this.codeMirror;
+    var anchor = cm.indexFromPos(cm.getCursor('anchor'));
+    var head = cm.indexFromPos(cm.getCursor('head'));
+    if (anchor > head) { // backwards selection
+      pos = head + 1;
+    } else {
+      pos = head;
+    }
+    var spans = this.annotationList_.getAnnotatedSpansForPos(pos);
+    this.currentEntityAttributes_ = {};
+
+    var attributes = {};
+    // Use the attributes to the left unless they're line attributes (in which case use the ones to the right.
+    if (spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {
+      attributes = spans[0].annotation.attributes;
+    } else if (spans.length > 1) {
+      firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
+      attributes = spans[1].annotation.attributes;
+    }
+    for(var attr in attributes) {
+      // Don't copy line or entity attributes.
+      if (_.string.startsWith(attr, ATTR.ENTITY_SENTINEL)) {
+        this.currentEntityAttributes_[attr] = attributes[attr];
+      }
+    }
   };
 
   RichTextCodeMirror.prototype.getLineAttributes_ = function(lineNum) {


### PR DESCRIPTION
firepad.richTextCodeMirror_.setEntityAttribute('ent_class', 'pull-right') works well, when cursor is positioned either right after the image. or before it in case, when it's on the begining of the line.
