### PR TITLE
Fixed getHtml and expose newLine

### DIFF
--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -91,6 +91,9 @@ firepad.Firepad = (function(global) {
     this.firebaseAdapter_.on('cursor', function() {
       self.trigger.apply(self, ['cursor'].concat([].slice.call(arguments)));
     });
+    this.richTextCodeMirror_.on('newLine', function() {
+      self.trigger.apply(self, ['newLine'].concat([].slice.call(arguments)));
+    });
     this.firebaseAdapter_.on('ready', function() {
       self.ready_ = true;
       if (this.ace_)
@@ -241,7 +244,7 @@ firepad.Firepad = (function(global) {
   Firepad.TODO_STYLE = '<style>ul.firepad-todo { list-style: none; margin-left: 0; padding-left: 0; } ul.firepad-todo > li { padding-left: 1em; text-indent: -1em; } ul.firepad-todo > li:before { content: "\\2610"; padding-right: 5px; } ul.firepad-todo > li.firepad-checked:before { content: "\\2611"; padding-right: 5px; }</style>\n';
   
   Firepad.prototype.getHtml = function() {
-    this.getHtmlFromRange(null, null);
+    return this.getHtmlFromRange(null, null);
   };
 
   Firepad.prototype.getHtmlFromSelection = function() {

--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -44,7 +44,7 @@ firepad.RichTextCodeMirror = (function () {
     this.outstandingChanges_ = { };
     this.dirtyLines_ = [];
   }
-  utils.makeEventEmitter(RichTextCodeMirror, ['change', 'attributesChange']);
+  utils.makeEventEmitter(RichTextCodeMirror, ['change', 'attributesChange', 'newLine']);
 
   // A special character we insert at the beginning of lines so we can attach attributes to it to represent
   // "line attributes."  E000 is from the unicode "private use" range.
@@ -828,6 +828,7 @@ firepad.RichTextCodeMirror = (function () {
 
   RichTextCodeMirror.prototype.newline = function() {
     var cm = this.codeMirror;
+    var self = this;
     if (!this.emptySelection_()) {
       cm.replaceSelection('\n', 'end', '+input');
     } else {
@@ -852,6 +853,7 @@ firepad.RichTextCodeMirror = (function () {
 
           // Don't mark new todo items as completed.
           if (listType === 'tc') attributes[ATTR.LIST_TYPE] = 't';
+          self.trigger('newLine', {line: cursorLine+1, attr: attributes});
         });
       }
     }


### PR DESCRIPTION
I accidentally broke getHtml (missing return). In addition, I'm providing a useful way to listen externally to the creation of new lines (enables us for instance on new line to look if the previous one contains X, and then put X again at the beginning of the new one => custom list types without touching Firepad // that's just an example of how it can be combined with entities)
