### PR TITLE
Remove `dist/firepad.min.js` from bower.json's `main` array.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Michael Lehenbauer"
   ],
   "description": "Collaborative Text Editing powered by Firebase",
-  "main": ["dist/firepad.js", "dist/firepad.min.js", "dist/firepad.css", "dist/firepad.eot"],
+  "main": ["dist/firepad.js", "dist/firepad.css", "dist/firepad.eot"],
   "license": "MIT",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Having both the regular and the minified version of the JS file in `main` leads to inclusion of both in the HTML file when a build tool like [grunt-bower-install](https://github.com/stephenplusplus/grunt-bower-install) is used. In addition to that, the filename of the minified version is `dist/firepad-min.js` and not `dist/firepad.min.js`. 
