### PR TITLE
Prevent following entities to be considered as one.

### DIFF
--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -334,6 +334,7 @@ firepad.RichTextCodeMirror = (function () {
       while (newNodesLen--) {
         var newNode = newNodes[newNodesLen];
         if (oldNode.pos == newNode.pos &&
+            oldNode.length == newNode.length &&
             oldNode.annotation.attributes['ent'] &&
             oldNode.annotation.attributes['ent'] == newNode.annotation.attributes['ent']) {
           var entityType = newNode.annotation.attributes['ent'];


### PR DESCRIPTION
This fix prevent this situation:
When inserting an entity after the same one (ex: a checkbox) firepad consider them as similar annotation and will prevent the 2 entity to be rendered correctly.
