### PR TITLE
Fix unindent when deleting indent

### DIFF
--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -1026,9 +1026,7 @@ firepad.RichTextCodeMirror = (function () {
         delete attributes[ATTR.LINE_INDENT];
       });
     } else if (backspaceAtStartOfLine && indent && indent > 0) {
-      this.updateLineAttributes(cursorPos.line, cursorPos.line, function(attributes) {
-        attributes[ATTR.LINE_INDENT]--;
-      });
+      this.unindent();
     } else {
       cm.deleteH(-1, "char");
     }


### PR DESCRIPTION
The actual problem with updating the indent is when you backspace the indent , it create a pre with attributes firepad-li-0 which is then misaligned with the normal lines (padding-left is 0 instead of 4px).

I think the best in that case is to remove the firepad-li-0 which is done by the unindent
