### PR TITLE
Split up sendOperation

### DIFF
--- a/lib/firebase-adapter.js
+++ b/lib/firebase-adapter.js
@@ -115,35 +115,44 @@ firepad.FirebaseAdapter = (function (global) {
     // Convert revision into an id that will sort properly lexicographically.
     var revisionId = revisionToId(this.revision_);
 
-    function doTransaction(revisionId, revisionData) {
+    this.sent_ = { id: revisionId, op: operation };
+    this.doTransaction_(revisionId, {
+      a: this.getAuthorId(),
+      o: operation.toJSON(),
+      t: Firebase.ServerValue.TIMESTAMP
+    }, callback);
+  };
 
-      self.ref_.child('history').child(revisionId).transaction(function(current) {
-        if (current === null) {
-          return revisionData;
-        }
-      }, function(error, committed, snapshot) {
-        if (error) {
-          if (error.message === 'disconnect') {
-            if (self.sent_ && self.sent_.id === revisionId) {
-              // We haven't seen our transaction succeed or fail.  Send it again.
-              setTimeout(function() {
-                doTransaction(revisionId, revisionData);
-              }, 0);
-            } else if (callback) {
-              callback(error, false);
-            }
-          } else {
-            utils.log('Transaction failure!', error);
-            throw error;
+  FirebaseAdapter.prototype.doTransaction_ = function(revisionId, revisionData, callback) {
+    var self = this;
+
+    this.ref_.child('history').child(revisionId).transaction(function(current) {
+      if (current === null) {
+        return revisionData;
+      }
+    }, function(error, committed, snapshot) {
+      if (error) {
+        if (error.message === 'disconnect') {
+          if (self.sent_ && self.sent_.id === revisionId) {
+            // We haven't seen our transaction succeed or fail.  Send it again.
+            setTimeout(function() {
+              self.doTransaction_(revisionId, revisionData);
+            }, 0);
+          } else if (callback) {
+            callback(error, false);
           }
         } else {
-          if (callback) callback(null, committed);
+          utils.log('Transaction failure!', error);
+          throw error;
         }
-      }, /*applyLocally=*/false);
-    }
+      } else {
+        if (callback) callback(null, committed);
+      }
+    }, /*applyLocally=*/false);
+  };
 
-    this.sent_ = { id: revisionId, op: operation };
-    doTransaction(revisionId, { a: self.userId_, o: operation.toJSON(), t: Firebase.ServerValue.TIMESTAMP });
+  FirebaseAdapter.prototype.getAuthorId = function() {
+    return this.userId_;
   };
 
   FirebaseAdapter.prototype.sendCursor = function (obj) {


### PR DESCRIPTION
creates `FirebaseAdapter::doTransaction_` and `FirebaseAdapter::getAuthorId`

Splitting out `doTransaction_` is nice because you avoid eating the closure construction overhead each time `sendOperation` is called.

Splitting out `getAuthorId` is nice to let users override this is if they want to control the `a` field that goes into the `history` ref in Firebase.