### PR TITLE
Add  transparency to "other user's" selections

### DIFF
--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -487,7 +487,7 @@ firepad.Firepad = (function(global) {
     }
     var hue = a/360;
 
-    return hsl2hex(hue, 1, 0.85);
+    return hsl2hex(hue, 1, 0.75);
   }
 
   function rgb2hex (r, g, b) {

--- a/lib/rich-text-codemirror-adapter.js
+++ b/lib/rich-text-codemirror-adapter.js
@@ -263,9 +263,9 @@ firepad.RichTextCodeMirrorAdapter = (function () {
       var selectionClassName = 'selection-' + color.replace('#', '');
       var transparency = 0.4;
       var rule = '.' + selectionClassName + ' {' +
-        ' background: ' + hexToRGB(color, transparency) + ';'
+        ' background: ' + hex2rgb(color, transparency) + ';'
         // fallback for browsers w/out rgba (rgb w/ transparency)
-        ' background: ' + hexToRGB(color) + ';\n'
+        ' background: ' + hex2rgb(color) + ';\n'
       '}';
       this.addStyleRule(rule);
 
@@ -374,15 +374,15 @@ firepad.RichTextCodeMirrorAdapter = (function () {
     return true;
   }
 
-  function hexToRGB (hex, transparency) {
-  	if (typeof hex !== 'string') {
-  		throw new TypeError('Expected a string');
-  	}
-  	hex = hex.replace(/^#/, '');
-  	if (hex.length === 3) {
-  		hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-  	}
-  	var num = parseInt(hex, 16);
+  function hex2rgb (hex, transparency) {
+    if (typeof hex !== 'string') {
+      throw new TypeError('Expected a string');
+    }
+    hex = hex.replace(/^#/, '');
+    if (hex.length === 3) {
+      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+    }
+    var num = parseInt(hex, 16);
     var rgb = [num >> 16, num >> 8 & 255, num & 255];
     var type = 'rgb';
     if (exists(transparency)) {
@@ -390,7 +390,7 @@ firepad.RichTextCodeMirrorAdapter = (function () {
       rgb.push(transparency);
     }
     // rgb(r, g, b) or rgba(r, g, b, t)
-  	return type + '(' + rgb.join(',') + ')';
+    return type + '(' + rgb.join(',') + ')';
   }
 
   function exists (val) {

--- a/lib/rich-text-codemirror-adapter.js
+++ b/lib/rich-text-codemirror-adapter.js
@@ -261,7 +261,12 @@ firepad.RichTextCodeMirrorAdapter = (function () {
     } else {
       // show selection
       var selectionClassName = 'selection-' + color.replace('#', '');
-      var rule = '.' + selectionClassName + ' { background: ' + color + '; }';
+      var transparency = 0.4;
+      var rule = '.' + selectionClassName + ' {' +
+        ' background: ' + hexToRGB(color, transparency) + ';'
+        // fallback for browsers w/out rgba (rgb w/ transparency)
+        ' background: ' + hexToRGB(color) + ';\n'
+      '}';
       this.addStyleRule(rule);
 
       var fromPos, toPos;
@@ -367,6 +372,29 @@ firepad.RichTextCodeMirrorAdapter = (function () {
       return false;
     }
     return true;
+  }
+
+  function hexToRGB (hex, transparency) {
+  	if (typeof hex !== 'string') {
+  		throw new TypeError('Expected a string');
+  	}
+  	hex = hex.replace(/^#/, '');
+  	if (hex.length === 3) {
+  		hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  	}
+  	var num = parseInt(hex, 16);
+    var rgb = [num >> 16, num >> 8 & 255, num & 255];
+    var type = 'rgb';
+    if (exists(transparency)) {
+      type = 'rgba';
+      rgb.push(transparency);
+    }
+    // rgb(r, g, b) or rgba(r, g, b, t)
+  	return type + '(' + rgb.join(',') + ')';
+  }
+
+  function exists (val) {
+    return val !== null && val !== undefined;
   }
 
   return RichTextCodeMirrorAdapter;


### PR DESCRIPTION
Other user's selection can make the text hard to read especially on when CodeMirror is set to a "dark" theme. The other user's selection are often pastel and if the "dark" theme has very light font they blend together. 

I have made a styling adjust in `RichTextCodeMirrorAdapter.prototype.setOtherCursor` that adds transparency to the others user's selection so that it blends better with any background and still allows the text to be readable.