### PR TITLE
[userlist] Remember to set displayName_ on name change

### DIFF
--- a/examples/firepad-userlist.js
+++ b/examples/firepad-userlist.js
@@ -75,12 +75,14 @@ var FirepadUserList = (function() {
     if (this.hasName_) nameHint.style.display = 'none';
 
     // Update Firebase when name changes.
+    var self = this;
     on(nameInput, 'change', function(e) {
       var name = nameInput.value || "Guest " + Math.floor(Math.random() * 1000);
       myUserRef.child('name').onDisconnect().remove();
       myUserRef.child('name').set(name);
       nameHint.style.display = 'none';
       nameInput.blur();
+      self.displayName_ = name;
       stopEvent(e);
     });
 


### PR DESCRIPTION
Because the userlist does this on initialize:

```js
this.firebaseOn_(ref.root().child('.info/connected'), 'value', function(s) {
  if (s.val() === true && self.displayName_) {
    var nameRef = ref.child(self.userId_).child('name');
    nameRef.onDisconnect().remove();
    nameRef.set(self.displayName_);
  }
});
```

Anytime the client reconnects, it will set its own name in Firebase to whatever `this.displayName_` is, even if the user has changed it post-initialize. Locally, this change won't be obvious to the user, because by default the input doesn't update, but other users will see the user reconnect with his or her old name (and be a bit confused about it).

I don't use this particular library personally anymore, but ran into this issue independently in my implementation, figure it'd be helpful to contribute it back to the example lib.