### PR TITLE
add Headless.dispose(); more assertReady enforcement in Firepad

### DIFF
--- a/lib/firebase-adapter.js
+++ b/lib/firebase-adapter.js
@@ -64,8 +64,10 @@ firepad.FirebaseAdapter = (function (global) {
   FirebaseAdapter.prototype.dispose = function() {
     this.removeFirebaseCallbacks_();
 
-    this.userRef_.child('cursor').remove();
-    this.userRef_.child('color').remove();
+    if (this.userRef_) {
+      this.userRef_.child('cursor').remove();
+      this.userRef_.child('color').remove();
+    }
 
     this.ref_ = null;
     this.document_ = null;
@@ -74,7 +76,8 @@ firepad.FirebaseAdapter = (function (global) {
 
   FirebaseAdapter.prototype.setUserId = function(userId) {
     if (this.userRef_) {
-      // clean up existing data.
+      // Clean up existing data.  Avoid nuking another user's data
+      // (if a future user takes our old name).
       this.userRef_.child('cursor').remove();
       this.userRef_.child('cursor').onDisconnect().cancel();
       this.userRef_.child('color').remove();

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -176,6 +176,7 @@ firepad.Firepad = (function(global) {
   };
 
   Firepad.prototype.setText = function(textPieces) {
+    this.assertReady_('setText');
     if (this.ace_) {
       return this.ace_.getSession().getDocument().setValue(textPieces);
     } else {
@@ -239,6 +240,7 @@ firepad.Firepad = (function(global) {
   };
 
   Firepad.prototype.getHtmlFromRange = function(start, end) {
+    this.assertReady_('getHtmlFromRange');
     var doc = (start != null && end != null) ?
       this.getOperationForSpan(start, end) :
       this.getOperationForSpan(0, this.codeMirror_.getValue().length);

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -24,6 +24,8 @@ firepad.Firepad = (function(global) {
       throw new Error('Couldn\'t find CodeMirror or ACE.  Did you forget to include codemirror.js or ace.js?');
     }
 
+    this.zombie_ = false;
+
     if (CodeMirror && place instanceof CodeMirror) {
       this.codeMirror_ = this.editor_ = place;
       var curValue = this.codeMirror_.getValue();

--- a/lib/headless.js
+++ b/lib/headless.js
@@ -27,8 +27,9 @@ firepad.Headless = (function() {
 
     this.entityManager_  = new EntityManager();
 
-    this.firebaseAdapter_        = new FirebaseAdapter(ref);
-    this.ready_          = false;
+    this.firebaseAdapter_ = new FirebaseAdapter(ref);
+    this.ready_ = false;
+    this.zombie_ = false;
   }
 
   Headless.prototype.getDocument = function(callback) {
@@ -45,6 +46,10 @@ firepad.Headless = (function() {
   }
 
   Headless.prototype.getText = function(callback) {
+    if (this.zombie_) {
+      throw new Error('You can\'t use a firepad.Headless after calling dispose()!');
+    }
+
     this.getDocument(function(doc) {
       var text = doc.apply('');
 
@@ -57,6 +62,10 @@ firepad.Headless = (function() {
   }
 
   Headless.prototype.setText = function(text, callback) {
+    if (this.zombie_) {
+      throw new Error('You can\'t use a firepad.Headless after calling dispose()!');
+    }
+
     var op = TextOperation().insert(text);
     this.sendOperationWithRetry(op, callback);
   }
@@ -82,6 +91,10 @@ firepad.Headless = (function() {
   Headless.prototype.getHtml = function(callback) {
     var self = this;
 
+    if (this.zombie_) {
+      throw new Error('You can\'t use a firepad.Headless after calling dispose()!');
+    }
+
     self.initializeFakeDom(function() {
       self.getDocument(function(doc) {
         callback(firepad.SerializeHtml(doc, self.entityManager_));
@@ -91,6 +104,10 @@ firepad.Headless = (function() {
 
   Headless.prototype.setHtml = function(html, callback) {
     var self = this;
+
+    if (this.zombie_) {
+      throw new Error('You can\'t use a firepad.Headless after calling dispose()!');
+    }
 
     self.initializeFakeDom(function() {
       var textPieces = ParseHtml(html, self.entityManager_);
@@ -121,6 +138,12 @@ firepad.Headless = (function() {
       });
     });
   }
+
+  Headless.prototype.dispose = function() {
+    this.zombie_ = true; // We've been disposed.  No longer valid to do anything.
+
+    this.firebaseAdapter_.dispose();
+  };
 
   return Headless;
 })();

--- a/lib/headless.js
+++ b/lib/headless.js
@@ -25,21 +25,22 @@ firepad.Headless = (function() {
       var ref = refOrPath;
     }
 
-    this.adapter        = new FirebaseAdapter(ref);
-    this.ready          = false;
-    this.entityManager  = new EntityManager();
+    this.entityManager_  = new EntityManager();
+
+    this.firebaseAdapter_        = new FirebaseAdapter(ref);
+    this.ready_          = false;
   }
 
   Headless.prototype.getDocument = function(callback) {
     var self = this;
 
-    if (self.ready) {
-      return callback(self.adapter.getDocument());
+    if (self.ready_) {
+      return callback(self.firebaseAdapter_.getDocument());
     }
 
-    self.adapter.on('ready', function() {
-      self.ready = true;
-      callback(self.adapter.getDocument());
+    self.firebaseAdapter_.on('ready', function() {
+      self.ready_ = true;
+      callback(self.firebaseAdapter_.getDocument());
     });
   }
 
@@ -83,7 +84,7 @@ firepad.Headless = (function() {
 
     self.initializeFakeDom(function() {
       self.getDocument(function(doc) {
-        callback(firepad.SerializeHtml(doc, self.entityManager));
+        callback(firepad.SerializeHtml(doc, self.entityManager_));
       });
     });
   }
@@ -92,7 +93,7 @@ firepad.Headless = (function() {
     var self = this;
 
     self.initializeFakeDom(function() {
-      var textPieces = ParseHtml(html, self.entityManager);
+      var textPieces = ParseHtml(html, self.entityManager_);
       var inserts    = firepad.textPiecesToInserts(true, textPieces);
       var op         = new TextOperation();
 
@@ -109,7 +110,7 @@ firepad.Headless = (function() {
 
     self.getDocument(function(doc) {
       var op = operation.clone()['delete'](doc.targetLength);
-      self.adapter.sendOperation(op, function(err, committed) {
+      self.firebaseAdapter_.sendOperation(op, function(err, committed) {
         if (committed) {
           if (typeof callback !== "undefined") {
             callback(null, committed);

--- a/lib/headless.js
+++ b/lib/headless.js
@@ -142,7 +142,14 @@ firepad.Headless = (function() {
   Headless.prototype.dispose = function() {
     this.zombie_ = true; // We've been disposed.  No longer valid to do anything.
 
-    this.firebaseAdapter_.dispose();
+    var firebaseAdapter = this.firebaseAdapter_;
+    if (this.ready_) {
+      firebaseAdapter.dispose();
+    } else {
+      firebaseAdapter.on('ready', function() {
+	firebaseAdapter.dispose();
+      });
+    }
   };
 
   return Headless;

--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -242,7 +242,7 @@ describe('Integration tests', function() {
         '<li>Cursor / selection synchronization.</li>' +
         '<li>And it\'s all fully collaborative!</li>' +
       '</ul>' +
-      '</div>'
+      '</div>';
 
     var headlessHtml = null;
     firepadHeadless.setHtml(html, function() {
@@ -250,6 +250,8 @@ describe('Integration tests', function() {
         headlessHtml = val;
       })
     });
+
+    waitsFor(function() { return firepadCm.ready_ }, 'firepad is ready');
 
     waitsFor(function() { return headlessHtml == firepadCm.getHtml(); }, 'firepad headless html matches cm-firepad html');
 

--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -159,6 +159,26 @@ describe('Integration tests', function() {
     waitsFor(function() { return syncHistory[syncHistory.length - 1] === true; }, 'synced again.');
   });
 
+  it('Performs Firepad.dispose', function(){
+    var ref = new Firebase('https://firepad-test.firebaseio-demo.com').push();
+    var cm = CodeMirror(cmDiv());
+    var firepad = new Firepad(ref, cm, { defaultText: "It\'s alive." });
+
+    waitsFor(function() { return firepad.ready_ }, 'firepad is ready');
+
+    runs(function() {
+      firepad.dispose();
+      // We'd like to know all firebase callbacks were removed.
+      // This does not prove there was no leak but it shows we tried.
+      expect(firepad.firebaseAdapter_.firebaseCallbacks_).toEqual([]);
+      expect(function() { firepad.isHistoryEmpty(); }).toThrow();
+      expect(function() { firepad.getText(); }).toThrow();
+      expect(function() { firepad.setText("I'm a zombie.  Braaaains..."); }).toThrow();
+      expect(function() { firepad.getHtml(); }).toThrow();
+      expect(function() { firepad.setHtml("<p>I'm a zombie.  Braaaains...</p>"); }).toThrow();
+    });
+  });
+
   it('Performs headless get/set plaintext & dispose', function(){
     var ref = new Firebase('https://firepad-test.firebaseio-demo.com').push();
     var cm = CodeMirror(cmDiv());

--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -282,4 +282,13 @@ describe('Integration tests', function() {
       waitsFor(function() { return headlessText == text; }, 'firepad headless matches text');
     });
   });
+
+  it('Safely performs Headless.dispose immediately after construction', function(){
+    var ref = new Firebase('https://firepad-test.firebaseio-demo.com').push();
+    var firepadHeadless = new Headless(ref);
+
+    runs(function() {
+      firepadHeadless.dispose();
+    });
+  });
 });

--- a/test/specs/integration.spec.js
+++ b/test/specs/integration.spec.js
@@ -159,7 +159,7 @@ describe('Integration tests', function() {
     waitsFor(function() { return syncHistory[syncHistory.length - 1] === true; }, 'synced again.');
   });
 
-  it('Performs headless get/set plaintext', function(){
+  it('Performs headless get/set plaintext & dispose', function(){
     var ref = new Firebase('https://firepad-test.firebaseio-demo.com').push();
     var cm = CodeMirror(cmDiv());
     var firepadCm = new Firepad(ref, cm);
@@ -175,13 +175,22 @@ describe('Integration tests', function() {
       var headlessText = null;
       firepadHeadless.getText(function(val) {
         headlessText = val;
-      })
+      });
 
       waitsFor(function() { return headlessText == text; }, 'firepad headless matches text');
     });
+
+    runs(function() {
+      firepadHeadless.dispose();
+      // We'd like to know all firebase callbacks were removed.
+      // This does not prove there was no leak but it shows we tried.
+      expect(firepadHeadless.firebaseAdapter_.firebaseCallbacks_).toEqual([]);
+      expect(function() { firepadHeadless.getText(function() {}); }).toThrow();
+      expect(function() { firepadHeadless.setText("I'm a zombie.  Braaaains..."); }).toThrow();
+    });
   });
 
-  it('Performs headless get/set html', function() {
+  it('Performs headless get/set html & dispose', function() {
     var ref = new Firebase('https://firepad-test.firebaseio-demo.com').push();
     var cm = CodeMirror(cmDiv());
     var firepadCm = new Firepad(ref, cm);
@@ -223,6 +232,15 @@ describe('Integration tests', function() {
     });
 
     waitsFor(function() { return headlessHtml == firepadCm.getHtml(); }, 'firepad headless html matches cm-firepad html');
+
+    runs(function() {
+      firepadHeadless.dispose();
+      // We'd like to know all firebase callbacks were removed.
+      // This does not prove there was no leak but it shows we tried.
+      expect(firepadHeadless.firebaseAdapter_.firebaseCallbacks_).toEqual([]);
+      expect(function() { firepadHeadless.getHtml(function() {}); }).toThrow();
+      expect(function() { firepadHeadless.setHtml("<p>I'm a zombie.  Braaaains...</p>"); }).toThrow();
+    });
   });
 
   it('Headless firepad takes a string path as well', function() {


### PR DESCRIPTION
The first 2 commits touching Headless should be a clear improvement;
the 2 touching Firepad are somewhat arbitrary and could break (arguably already broken) clients.

Initially I wrote the trivial Headless.dispose and wasn't sure how to meaningfully test it — that all firebase callbacks are removed, which is the reason I want Headless.dispose to exist.  So I wrote the trivial test that calling zombie methods throws — and what do you know, `FirebaseAdapter.dispose()` crashed!
Turns out Headless initializes FirebaseAdapter with less parameters so userRef_ might be null.
(Afterwards I figured out the imperfect but "meaningful" test of `firebaseAdapter_.firebaseCallbacks_`.)

Enboldened by this victory of testing I noticed that `Firepad.dispose()` has no tests.
So I added a similar test — and what do you know, it failed :-)  In a minor way - `getHtml()` after `dispose()` wasn't throwing.

Here comes the arbitrary part: how much we should enforce ready/zombie with `assertReady()`?
Calling anything after dispose() is clearly bad.
In principle the docs say "You must wait for 'ready' event to fire before calling any other methods."
- Being lazy I decided to only look at Firepad's documented methods.
- I excluded `setUserId()` & `setUserColor()` - they're probably safe, and it's natural to expect passing id/color to constructor should be equivalent setting them quickly after construction.
=> `setText` was enforced on CodeMirror path (via `insertText`) but apparently not on Ace path.  So I added a common assertReady.
=> `getHtml` and friends weren't enforced, so I added an assertReady.

Even this subset broke another test that was calling Firepad.getHtml() without waiting for ready.
I think it's likely this will break some client.  OTOH what would getText currently return if called before ready?

- `insertEntity` isn't enforced.  I've never used it and there is no example how to test it, and I simply  forgot about it :-)

- It'd make sense to exclude `dispose()` — if we're no longer interested in this pad, why should we wait for it to load?  However if you now remove the wait from my "Performs Firepad.dispose" test, it crashes on 'null' is not an object (evaluating 'this.ref_.child') somewhere in firebase-adapter.js — apparently despite clearing the callbacks, there is some delayed code that crashes after `dispose()` has cleared `ref_`.
  It seems solving this would require either a fragile sprinkle of `zombie_` checks or `dispose()` delaying itself until ready (which misses the point of aborting unnecessary loading).