### PR TITLE
Fix for newline picking wrong attributes from prev line

### DIFF
--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -907,6 +907,7 @@ firepad.RichTextCodeMirror = (function () {
     var cm = this.codeMirror;
     var anchor = cm.indexFromPos(cm.getCursor('anchor')), head = cm.indexFromPos(cm.getCursor('head'));
     var pos = head;
+    var newline=false;
     if (anchor > head) { // backwards selection
       // Advance past any newlines or line sentinels.
       while(pos < this.end()) {
@@ -918,6 +919,9 @@ firepad.RichTextCodeMirror = (function () {
       if (pos < this.end())
         pos++; // since we're going to look at the annotation span to the left to decide what attributes to use.
     } else {
+      c = this.getRange(pos-1, pos);
+      if (c=='\n' || c==LineSentinelCharacter) newline=true;
+
       // Back up before any newlines or line sentinels.
       while(pos > 0) {
         c = this.getRange(pos-1, pos);
@@ -932,7 +936,7 @@ firepad.RichTextCodeMirror = (function () {
     var attributes = {};
     // Use the attributes to the left unless they're line attributes (in which case use the ones to the right.
     if (spans.length > 0 && (!(ATTR.LINE_SENTINEL in spans[0].annotation.attributes))) {
-      attributes = spans[0].annotation.attributes;
+      attributes = spans[newline? spans.length-1 : 0].annotation.attributes;
     } else if (spans.length > 1) {
       firepad.utils.assert(!(ATTR.LINE_SENTINEL in spans[1].annotation.attributes), "Cursor can't be between two line sentinel characters.");
       attributes = spans[1].annotation.attributes;


### PR DESCRIPTION
Fixed an issue where a newline would pick the attributes of the line before even when these attributes where turned off at the last char (of the previous line)
(https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/firepad-io/oQaDX95vz_Q(