### PR TITLE
Don't set inclusiveLeft on collapsed sentinels

### DIFF
--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -833,7 +833,7 @@ firepad.RichTextCodeMirror = (function () {
     // Create a marker to cover this series of sentinel characters.
     // NOTE: The reason we treat them as a group (one marker for all subsequent sentinel characters instead of
     // one marker for each sentinel character) is that CodeMirror seems to get angry if we don't.
-    var markerOptions = { inclusiveLeft: true, collapsed: true };
+    var markerOptions = { collapsed: true };
     if (element) {
       markerOptions.replacedWith = element;
     }


### PR DESCRIPTION
Fixes #82 

`inclusiveLeft` in collapsed/atomic ranges means something pretty specific: 

> Atomic ranges act as a single unit when cursor movement is concerned—i.e. it is impossible to place the cursor inside of them. In atomic ranges, inclusiveLeft and inclusiveRight have a different meaning—they will prevent the cursor from being placed respectively directly before and directly after the range.

Which screws with the cursor movement in the related issue. Is there a particular reason this attribute was originally set, @mikelehen or @iclems?