### PR TITLE
fix set html inserts extra new line at the end

### DIFF
--- a/lib/text-pieces-to-inserts.js
+++ b/lib/text-pieces-to-inserts.js
@@ -16,7 +16,7 @@ firepad.textPiecesToInserts = function(atNewLine, textPieces) {
     atNewLine = string[string.length-1] === '\n';
   }
 
-  function insertLine(line) {
+  function insertLine(line, withNewline) {
     // HACK: We should probably force a newline if there isn't one already.  But due to
     // the way this is used for inserting HTML, we end up inserting a "line" in the middle
     // of text, in which case we don't want to actually insert a newline.
@@ -28,12 +28,12 @@ firepad.textPiecesToInserts = function(atNewLine, textPieces) {
       insert(line.textPieces[i]);
     }
 
-    insert('\n');
+    if (withNewline) insert('\n');
   }
 
   for(var i = 0; i < textPieces.length; i++) {
     if (textPieces[i] instanceof firepad.Line) {
-      insertLine(textPieces[i]);
+      insertLine(textPieces[i], i<textPieces.length-1);
     } else {
       insert(textPieces[i]);
     }


### PR DESCRIPTION
insertHtmlAtCursor etc inserts a newline (\n) after every line including the last line. The newline after the last line should not be there.

This becomes important when trying to implement a paste html functionality using insertHtmlAtCursor  instead of the default CM paste. Pasting (inserting html) inside a line gets broken because you get an extra linebreak at the end that pushes the next letter to a new line.

This pull request changes firepad.textPiecesToInserts to not insert a newline after the last line. Also included is an updated examples\firepad.js so that this fix can be linked to from jsfiddle etc.
