### PR TITLE
Exclude jsdom from browserify builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "https://github.com/firebase/firepad.git"
   },
+  "browser": {
+    "jsdom": false
+  },
   "bugs": {
     "url": "https://github.com/firebase/firepad/issues"
   },


### PR DESCRIPTION
This fixes compatibility with browserify: #231.