### PR TITLE
Added version numbers to bower.json and package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.0.0",
+  "version": "1.4.0",
   "authors": [
     "Firebase (https://firebase.google.com/)",
     "Michael Lehenbauer <michael@firebase.com>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firepad",
   "description": "Collaborative text editing powered by Firebase",
-  "version": "0.0.0",
+  "version": "1.4.0",
   "author": "Firebase (https://firebase.google.com/)",
   "contributors": [
     "Michael Lehenbauer <michael@firebase.com>"


### PR DESCRIPTION
### Description

Catapult (the internal tool we use to release Firebase JavaScript libraries) now works without the `0.0.0` version placeholder in the `bower.json` and `package.json` files. So, we can finally add the actual version numbers back into these files.

### Code sample

N/A