### PR TITLE
Fix a leak caused by a typo from 2013

### DIFF
--- a/lib/ace-adapter.coffee
+++ b/lib/ace-adapter.coffee
@@ -23,7 +23,7 @@ class firepad.ACEAdapter
   detach: ->
     @ace.removeListener 'change', @onChange
     @ace.removeListener 'blur', @onBlur
-    @ace.removeListener 'focus', @onCursorActivity
+    @ace.removeListener 'focus', @onFocus
     @aceSession.selection.removeListener 'changeCursor', @onCursorActivity
 
   onChange: (change) =>


### PR DESCRIPTION
A few lines above, we're binding the focus event to `onFocus`, but here, the original author is unbinding `onCursorActivity` from the focus event, which means `onFocus` never gets unbound! This commit fixes that.