### PR TITLE
Include firebase ^4 in acceptable version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "jsdom": ">3",
-    "firebase": "3.x.x"
+    "firebase": "^3 || ^4"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
### Description

This updates `package.json` to allow firebase versions ^3 and ^4. Firebase 4.0.0 was released on May 17, 2017. Projects which are using firebase _and_ firepad will benefit from this: When bundling an app using both firebase and firepad, firepad will not come with its own bundled copy of the firebase library, instead they can use a shared copy of firebase with a version pegged by the project consuming firepad.