### PR TITLE
Changed monaco-adapter to respect line endings

### DIFF
--- a/lib/monaco-adapter.js
+++ b/lib/monaco-adapter.js
@@ -58,13 +58,13 @@ firepad.MonacoAdapter = (function() {
   MonacoAdapter.prototype.operationFromMonacoChange = function(change) {
     text = change.changes[0].text;
     start = this.indexFromPos(change.changes[0].range, 'start');
-    restLength = this.lastDocLines.join('\n').length - start;
+    restLength = this.lastDocLines.join(this.monacoModel.getEOL()).length - start;
     text_ins = change.changes[0].text;
     rangeLen = change.changes[0].rangeLength;
 
     if (change.changes[0].rangeLength > 0) {
       restLength -= rangeLen;
-      text = this.lastDocLines.join('\n')
+      text = this.lastDocLines.join(this.monacoModel.getEOL())
           .slice(start, start+rangeLen);
     }
 
@@ -137,7 +137,7 @@ firepad.MonacoAdapter = (function() {
       if (index <= line.length) {
         break;
       }
-      index -= line.length + 1;
+      index -= line.length + this.monacoModel.getEOL().length;
     }
     return {
       row: row + 1,
@@ -154,12 +154,12 @@ firepad.MonacoAdapter = (function() {
     index = 0;
     if (upto === 'start') {
       for (row = 1; row < range.startLineNumber; row++) {
-        index += lines[row-1].length + 1
+        index += lines[row-1].length + this.monacoModel.getEOL().length;
       }
       return index + range.startColumn -1;
     } else {
       for (row = 1; row < range.endLineNumber; row++) {
-        index += lines[row-1].length + 1
+        index += lines[row-1].length + this.monacoModel.getEOL().length;
       }
       return index + range.endColumn -1;
     }


### PR DESCRIPTION
When monaco was not using '\n' as its line ending then the calculations for text positions where all incorrect which caused the creation of faulty TextOps

This simply uses the monaco.getModel().getEOF() to access the currently used line feed and calculate positions based on that. 

