### PR TITLE
Write actual version to generated dist file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+const package = require('./package.json');
+
 module.exports = function (grunt) {
   grunt.initConfig({
     coffeelint: {
@@ -42,7 +44,7 @@ module.exports = function (grunt) {
             ' * it requires no server-side code and can be added to any web app simply by',
             ' * including a couple JavaScript files.',
             ' *',
-            ' * Firepad 0.0.0',
+            ' * Firepad ' + package.version,
             ' * http://www.firepad.io/',
             ' * License: MIT',
             ' * Copyright: 2014 Firebase',


### PR DESCRIPTION
### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

The generated `dist/firepad.js` file has the version `0.0.0` in its header always. This PR updates this so that now the version in the `package.json` file will be used there instead.