### PR TITLE
Update version of rdiscount to support macOS Big Sur

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdiscount (2.2.0.1)
+    rdiscount (2.2.0.2)
     rouge (3.17.0)
     safe_yaml (1.0.5)
     sass (3.7.4)


### PR DESCRIPTION
### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

This updates the version of `rdiscount` used for building the docs site. This version fixes building the dependency on macOS Big Sur.