### PR TITLE
Add TS types definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,104 @@
+import firebase from 'firebase/app';
+import CodeMirror from 'codemirror';
+import monaco from 'monaco-editor';
+interface BaseOptions {
+    // The user ID for the person editing. (default: random)
+    userId?: string;
+    // A css color (e.g. "#ccc") for this user's cursor. (default: generated from userId)
+    userColor?: string;
+    // Text to initialize the Firepad with if history is empty. (default: null)
+    defaultText?: string | null;
+}
+
+interface CodeMirrorOptions extends BaseOptions{
+  // Adds a toolbar with buttons for bold, italic, etc. (default: false)
+  richTextToolbar?: boolean;
+  // Maps Ctrl-B to bold, etc. (default: false)
+  richTextShortcuts?: boolean;
+}
+
+declare class Firepad {
+  constructor(
+    firebaseRef: firebase.database.Reference,
+    editor: CodeMirror.Editor | monaco.editor.ICodeEditor | any,
+    options?: CodeMirrorOptions | BaseOptions,
+  );
+
+  on: (event: string, callback: (...args: any[]) => void) => void;
+  off: (event: string, callback: (...args: any[]) => void) => void;
+
+  getText: () => string;
+  setText: (text: string) => void;
+  getHtml: () => string;
+  setHtml: (html: string) => void;
+  isHistoryEmpty: () => boolean;
+  registerEntity: (type: string, options: {[key: string]: any}) => void;
+  setUserId: (userId: string) => void;
+  setUserColor: (color: string) => void;
+  getOption: (option: string, def: any) => any;
+  dispose: () => void;
+
+  /* CodeMirror only */
+  bold: () => void;
+  italic: () => void;
+  underline: () => void;
+  strike: () => void;
+  fontSize: (size: number) => void;
+  font: (font: string) => void;
+  color: (color: string) => void;
+  highlight: () => void;
+  align: (alignment: 'left' | 'right' | 'center') => void;
+  orderedList: () => void;
+  unorderedList: () => void;
+  todo: () => void;
+  newline: () => void;
+  deleteLeft: () => void;
+  deleteRight: () => void;
+  indent: () => void;
+  unindent: () => void;
+  undo: () => void;
+  redo: () => void;
+  insertEntity: (type: string, attributes: {[key: string]: any}, origin: string) => void;
+  insertEntityAt: (index: string, type: string, attributes: {[key: string]: any}, origin: string) => void;
+}
+
+declare class TextOperation {
+  constructor();
+  equals: (other: TextOperation) => boolean;
+  retain: (n: number, attributes?: {[key: string]: any}) => this;
+  insert: (str: string, attributes?: {[key: string]: any}) => this;
+  delete: (n: string | number) => this;
+  isNoop: () => boolean;
+  clone: () => TextOperation;
+  toString: () => string;
+  toJSON: () => any[];
+  fromJSON: (objs: any[]) => void;
+  apply: (str: string, oldAttributes?: {[key: string]: any}[], newAttributes?: {[key: string]: any}[]) => string;
+  invert: (str: string) => TextOperation;
+  compose: (operation2: TextOperation) => TextOperation;
+  shouldBeComposedWith: (other: TextOperation) => boolean;
+  shouldBeComposedWithInverted: (other: TextOperation) => boolean;
+
+  transform: (other: TextOperation) => [TextOperation, TextOperation];
+
+  static transformAttributes: (attributes1: {[key: string]: any}, attributes2: {[key: string]: any}) => [{[key: string]: any}, {[key: string]: any}];
+  static tranform: (operation1: TextOperation, operation2: TextOperation) => [TextOperation, TextOperation];
+}
+
+declare namespace Firepad {
+  export function fromCodeMirror(firebaseRef: firebase.database.Reference, codeMirror: CodeMirror.Editor, options?: CodeMirrorOptions): Firepad;
+  export function fromACE(firebaseRef: firebase.database.Reference, ace: any, options?: BaseOptions): Firepad;
+  export function fromMonaco(firebaseRef: firebase.database.Reference, monaco: monaco.editor.ICodeEditor, options?: BaseOptions): Firepad;
+
+  export class Headless {
+    constructor(refOrPath: firebase.database.Reference | string);
+    getDocument(callback: (document: TextOperation) => void): void;
+    getText(callback: (text: string) => void): void;
+    setText(text: string, callback?: (err: null, committed: boolean) => void): void;
+    getHtml(callback: (html: string) => void): void;
+    setHtml: (html: string, callback?: (err: null, committed: boolean) => void) => void;
+    dispose(): void;
+  }
+}
+
+export = Firepad;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "collaborative"
   ],
   "main": "dist/firepad.min.js",
+  "types": "index.d.ts",
   "files": [
     "dist/**",
     "LICENSE",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
+    "@types/codemirror": "^5.60.2",
     "codemirror": "^5.52.2",
     "coveralls": "^3.0.11",
     "grunt": "^1.1.0",


### PR DESCRIPTION
### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Closes #366 

Adds a typescript definition file for the [documented API](https://firepad.io/docs) of Firepad. It does export additional stuff (`Formatting`, `Entity`, etc.), but these aren't something I'd expect an end user of Firepad to use.