### PR TITLE
Ace fixes

### DIFF
--- a/lib/editor-client.js
+++ b/lib/editor-client.js
@@ -138,7 +138,11 @@ firepad.EditorClient = (function () {
     var compose = this.undoManager.undoStack.length > 0 &&
       inverse.shouldBeComposedWithInverted(last(this.undoManager.undoStack).wrapped);
     var inverseMeta = new SelfMeta(this.cursor, cursorBefore);
-    this.undoManager.add(new WrappedOperation(inverse, inverseMeta), compose);
+    
+    if (this.editorAdapter.ready) {
+      this.undoManager.add(new WrappedOperation(inverse, inverseMeta), compose);
+    }
+    
     this.applyClient(textOperation);
   };
 

--- a/lib/firepad.js
+++ b/lib/firepad.js
@@ -132,6 +132,8 @@ firepad.Firepad = (function(global) {
       if (defaultText && self.isHistoryEmpty()) {
         self.setText(defaultText);
       }
+      
+      self.editorAdapter_.ready = true;
 
       self.trigger('ready');
     });

--- a/lib/text-operation.js
+++ b/lib/text-operation.js
@@ -452,6 +452,11 @@ firepad.TextOperation = (function () {
       // delete key.
       return (startB + simpleB.chars === startA) || startA === startB;
     }
+    
+    // undo text replace in one go
+    if (simpleA.isDelete() && simpleB.isInsert()) {
+      return startA === startB;
+    }
 
     return false;
   };

--- a/lib/undo-manager.js
+++ b/lib/undo-manager.js
@@ -9,7 +9,7 @@ firepad.UndoManager = (function () {
 
   // Create a new UndoManager with an optional maximum history size.
   function UndoManager (maxItems) {
-    this.maxItems  = maxItems || 50;
+    this.maxItems  = maxItems || 500;
     this.state = NORMAL_STATE;
     this.dontCompose = false;
     this.undoStack = [];


### PR DESCRIPTION
Fix issue where pressing undo after initial load, clears the editor.
Single undo for text that was typed over. Before it would delete and restore in two undos.
Upped initial undo limit from 50 to 500.
